### PR TITLE
fix: table header should be sticky

### DIFF
--- a/src/Components/Tables/Tables.jsx
+++ b/src/Components/Tables/Tables.jsx
@@ -1,4 +1,5 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect } from "react";
+import { makeStyles } from "@material-ui/core/styles";
 import {
   TableContainer,
   Table,
@@ -9,74 +10,87 @@ import {
   Grid,
   Card,
   CardContent,
-  Paper
-} from '@material-ui/core';
+  Paper,
+} from "@material-ui/core";
 
-import TopBar from '../TopBar/TopBar';
-import { fetchSummaryData } from '../../api-handler/index';
+import TopBar from "../TopBar/TopBar";
+import { fetchSummaryData } from "../../api-handler/index";
 
-import styles from './Tables.module.css';
+const useStyles = makeStyles({
+  root: {
+    width: "100%",
+  },
+  container: {
+    maxHeight: 440,
+  },
+});
 
 const Tables = () => {
+  const styles = useStyles();
   const [data, setData] = useState([]);
 
   useEffect(() => {
     const fetchAPI = async () => {
       const summaryData = await fetchSummaryData();
       setData(summaryData);
-      console.log(summaryData)
-    }
+    };
     fetchAPI();
-  }, [])
+  }, []);
 
-  const summaryTableBody = data.map((item, index) => {
-    return (
-      <TableRow key={index}>
-        <TableCell>{item.Country}</TableCell>
-        <TableCell>{item.NewConfirmed}</TableCell>
-        <TableCell>{item.NewDeaths}</TableCell>
-        <TableCell>{item.NewRecovered}</TableCell>
-        <TableCell>{item.TotalConfirmed}</TableCell>
-        <TableCell>{item.TotalDeaths}</TableCell>
-        <TableCell>{item.TotalRecovered}</TableCell>
-      </TableRow>
-    )
-  })
+  const columns = [
+    { id: "Country", label: "Country" },
+    { id: "NewConfirmed", label: "Newly Confirmed" },
+    { id: "NewDeaths", label: "New Deaths" },
+    { id: "NewRecovered", label: "Newly Recovered" },
+    { id: "TotalConfirmed", label: "Confirmed" },
+    { id: "TotalDeaths", label: "Deaths" },
+    { id: "TotalRecovered", label: "Recovered" },
+  ];
 
   return (
     <>
       <TopBar />
-      <div className={styles.container}>
-        <Paper className={styles.container}>
-          <Grid spacing={3} align='center'>
-            <Grid item component={Card} className={styles.container}>
-              <CardContent className={styles.container}>
-                <TableContainer className={styles.container}>
-                  <Table stickyHeader={true} aria-label="sticky table" className={styles.container}>
-                    <TableHead className={styles.head}>
-                      <TableRow hover role="checkbox" tabIndex={-1}>
-                        <TableCell key={1}>{'Country'}</TableCell>
-                        <TableCell key={2}>{'Newly Confirmed'}</TableCell>
-                        <TableCell key={3}>{'New Deaths'}</TableCell>
-                        <TableCell key={4}>{'Newly Recovered'}</TableCell>
-                        <TableCell key={5}>{'Confirmed'}</TableCell>
-                        <TableCell key={6}>{'Deaths'}</TableCell>
-                        <TableCell key={7}>{'Recovered'}</TableCell>
-                      </TableRow>
-                    </TableHead>
-                    <TableBody>
-                      {summaryTableBody}
-                    </TableBody>
-                    <caption>Courtesy of https://api.covid19api.com</caption>
-                  </Table>
-                </TableContainer>
-              </CardContent>
-            </Grid>
+      <Paper className={styles.root}>
+        <Grid spacing={3} align="center">
+          <Grid item component={Card}>
+            <CardContent>
+              <TableContainer className={styles.container}>
+                <Table stickyHeader aria-label="sticky table">
+                  <TableHead>
+                    <TableRow>
+                      {columns.map((column) => (
+                        <TableCell key={column.id}>{column.label}</TableCell>
+                      ))}
+                    </TableRow>
+                  </TableHead>
+                  <TableBody>
+                    {data.map((row) => {
+                      return (
+                        <TableRow
+                          hover
+                          role="checkbox"
+                          tabIndex={-1}
+                          key={row.CountryCode}
+                        >
+                          {columns.map((column) => {
+                            const value = row[column.id];
+                            return (
+                              <TableCell key={column.id}>{value}</TableCell>
+                            );
+                          })}
+                        </TableRow>
+                      );
+                    })}
+                  </TableBody>
+                  <caption>Courtesy of https://api.covid19api.com</caption>
+                </Table>
+              </TableContainer>
+            </CardContent>
           </Grid>
-        </Paper>
-      </div>
+        </Grid>
+      </Paper>
     </>
-  )
-}
+  );
+};
 
 export default Tables;

--- a/src/Components/Tables/Tables.module.css
+++ b/src/Components/Tables/Tables.module.css
@@ -1,4 +1,0 @@
-.container {
-  justify-content: center;
-  text-align: center;
-}


### PR DESCRIPTION
**Fix**

A "max height" CSS attribute added to the `TableContainer` component.

**Issue**

The `TableContainer` component needed a max height CSS attribute set for Material's UI sticky header to work.

**References**

https://material-ui.com/components/tables/#fixed-header

